### PR TITLE
Fix footnote heading formatting

### DIFF
--- a/word_document_server/tools/footnote_tools.py
+++ b/word_document_server/tools/footnote_tools.py
@@ -229,8 +229,9 @@ async def add_note(
             if not footnote_section_found:
                 # Add footnotes section
                 doc.add_paragraph("\\n").add_run()
-                footnotes_heading = doc.add_paragraph("Footnotes:")
-                footnotes_heading.bold = True
+                footnotes_heading = doc.add_paragraph()
+                footnotes_heading.add_run("Footnotes:")
+                footnotes_heading.runs[0].bold = True
             
             # Add footnote text
             footnote_para = doc.add_paragraph(f"{symbol} {note_text}")


### PR DESCRIPTION
## Summary
- adjust footnote heading creation
- bold the heading via the run instead of the paragraph

## Testing
- `python test_enhanced_features.py` *(fails: ImportError: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af5339020832e9f5e2b3044a6900e