### PR TITLE
Allow deleting text with empty replacement

### DIFF
--- a/test_enhanced_features.py
+++ b/test_enhanced_features.py
@@ -147,6 +147,16 @@ async def test_enhanced_search_replace():
         whole_words_only=False
     )
     print(f"Result: {result}")
+
+    # Test 4: Delete a word using empty replacement
+    print("\nTest 4: Delete 'mesophase' occurrences...")
+    result = await enhanced_search_and_replace(
+        filename=filename,
+        find_text="mesophase",
+        replace_text="",
+        match_case=False
+    )
+    print(f"Result: {result}")
     
     return filename
 

--- a/word_document_server/tools/content_tools.py
+++ b/word_document_server/tools/content_tools.py
@@ -487,7 +487,8 @@ def enhanced_search_and_replace(document_id: str = None, filename: str = None,
         document_id: Session document ID (preferred)
         filename: Path to the Word document (legacy, for backward compatibility)
         find_text: Text or regex pattern to search for
-        replace_text: Text to replace with (supports regex groups like $1, $2 if use_regex=True)
+        replace_text: Text to replace with (supports regex groups like $1, $2 if use_regex=True).
+            Use an empty string "" to delete the matched text.
         apply_formatting: Whether to apply formatting to the replaced text
         bold: Set replaced text bold (True/False)
         italic: Set replaced text italic (True/False)
@@ -531,7 +532,7 @@ def enhanced_search_and_replace(document_id: str = None, filename: str = None,
     if not find_text:
         return "Error: find_text parameter is required"
     
-    if not replace_text:
+    if replace_text is None:
         return "Error: replace_text parameter is required"
     
     if not os.path.exists(filename):


### PR DESCRIPTION
## Summary
- allow passing empty string to delete matches in `enhanced_search_and_replace`
- document new deletion behaviour in docstring
- add deletion example to the feature demonstration tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af60520c0832e80c70f347d98e60c