### PR TITLE
Fix sync call examples

### DIFF
--- a/README_ENHANCED.md
+++ b/README_ENHANCED.md
@@ -66,7 +66,7 @@ The enhanced search and replace feature solves the fundamental problem of charac
 
 ```python
 # Example: Format research terms with semantic targeting
-await enhanced_search_and_replace(
+enhanced_search_and_replace(
     filename="research_paper.docx",
     find_text="polycaprolactone",
     replace_text="polycaprolactone",

--- a/test_enhanced_features.py
+++ b/test_enhanced_features.py
@@ -122,7 +122,7 @@ async def test_enhanced_search_replace():
     
     # Test 1: Basic enhanced search and replace with formatting
     print("Test 1: Replace 'PCL' with formatted version...")
-    result = await enhanced_search_and_replace(
+    result = enhanced_search_and_replace(
         filename=filename,
         find_text="PCL",
         replace_text="PCL",
@@ -134,12 +134,12 @@ async def test_enhanced_search_replace():
     
     # Test 2: Format specific research terms
     print("\nTest 2: Format research paper terms...")
-    result = await format_research_paper_terms(filename)
+    result = format_research_paper_terms(filename)
     print(f"Result: {result}")
     
     # Test 3: Format statistical terms
     print("\nTest 3: Format statistical significance values...")
-    result = await format_specific_words(
+    result = format_specific_words(
         filename=filename,
         word_list=["p < 0.05", "r²", "±"],
         bold=True,


### PR DESCRIPTION
## Summary
- correct README example to remove `await` before `enhanced_search_and_replace`
- adjust tests to call synchronous helpers without `await`

## Testing
- `pip install -r requirements.txt`
- `python test_enhanced_features.py` *(fails: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af608e338832ead677713fb09f90f