### PR TITLE
Handle $n groups for regex replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Specialized functionality for professional workflows:
 - **Case-insensitive** search options
 - **Whole word matching**
 - **Advanced formatting** application to replaced text
-- **Group substitutions** for regex patterns
+- **Group substitutions** for regex patterns (use `$1` style references)
+
+`$1` style group references are automatically converted to Python's `\1` syntax when `use_regex=True`.
 
 ```python
 # Regex date format conversion

--- a/README_ENHANCED.md
+++ b/README_ENHANCED.md
@@ -12,7 +12,7 @@ This enhanced server solves critical limitations in LLM-friendly document manipu
 
 #### 1. **Enhanced Search & Replace with Formatting**
 - ✅ **Solves LLM character positioning problem** - No more counting characters!
-- ✅ Semantic text targeting with regex support
+- ✅ Semantic text targeting with regex support (use `$1` style groups)
 - ✅ Simultaneous text replacement and formatting
 - ✅ Batch word formatting for research terms
 - ✅ Academic research helpers (PCL terminology, statistical notation)
@@ -84,6 +84,7 @@ await format_research_paper_terms("research_paper.docx")
 - Semantic text matching
 - Simultaneous replacement and formatting
 - Support for regex patterns and whole-word matching
+- `$1` style group references for regex replacements
 - Academic research terminology helpers
 
 ### Review Tools

--- a/test_enhanced_features.py
+++ b/test_enhanced_features.py
@@ -147,7 +147,17 @@ async def test_enhanced_search_replace():
         whole_words_only=False
     )
     print(f"Result: {result}")
-    
+
+    # Test 4: Regex replacement with $1 group reference
+    print("\nTest 4: Regex group substitution...")
+    result = await enhanced_search_and_replace(
+        filename=filename,
+        find_text=r"(\d+)°C and (\d+)°C",
+        replace_text=r"$2°C and $1°C",
+        use_regex=True
+    )
+    print(f"Result: {result}")
+
     return filename
 
 

--- a/word_document_server/tools/content_tools.py
+++ b/word_document_server/tools/content_tools.py
@@ -547,6 +547,8 @@ def enhanced_search_and_replace(document_id: str = None, filename: str = None,
         try:
             import re
             re.compile(find_text)
+            # Convert $1 style groups to Python \1 syntax
+            replace_text = re.sub(r'\$(\d+)', r'\\\1', replace_text)
         except re.error as e:
             return f"Invalid regex pattern '{find_text}': {str(e)}"
     


### PR DESCRIPTION
## Summary
- allow `$n` style backreferences in `enhanced_search_and_replace`
- document this capability in both READMEs
- test regex replacement using `$1`

## Testing
- `pip install -r requirements.txt`
- `python test_enhanced_features.py` *(fails: ImportError: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af60692cc832eaaa6884f37128d1b