### PR TITLE
Fix __all__ export for DocumentSessionManager

### DIFF
--- a/word_document_server/tools/session_tools.py
+++ b/word_document_server/tools/session_tools.py
@@ -4,7 +4,10 @@ Session management tools for Word Document Server.
 Provides MCP tools for managing document sessions with simple IDs,
 eliminating the need to pass full file paths for every operation.
 """
-from word_document_server.session_manager import get_session_manager
+from word_document_server.session_manager import (
+    DocumentSessionManager,
+    get_session_manager,
+)
 
 
 def open_document(document_id: str, file_path: str) -> str:


### PR DESCRIPTION
## Summary
- import `DocumentSessionManager` in `session_tools` so it is re-exported in `__all__`

## Testing
- `pytest -q` *(fails: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af816e4bc832ea578c2a46d1f9cd4