### PR TITLE
Remove unused title_match variable

### DIFF
--- a/word_document_server/tools/section_tools.py
+++ b/word_document_server/tools/section_tools.py
@@ -336,14 +336,6 @@ async def get_sections(
                                 extract_run_formatting(run, formatting_detail)
                             )
                 
-                # Check if this matches target section (if specified)
-                title_match = False
-                if section_title:
-                    if case_sensitive:
-                        title_match = section_title in paragraph.text
-                    else:
-                        title_match = section_title.lower() in paragraph.text.lower()
-                
                 # Add to appropriate location
                 if heading_level == 1 or not sections:
                     sections.append(section_info)


### PR DESCRIPTION
## Summary
- remove unused title_match logic from section parsing

## Testing
- `pip install -r requirements.txt`
- `python test_enhanced_features.py` *(fails: ImportError: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af857473c832ea6755defdaa241f3