### PR TITLE
Validate table dimensions

### DIFF
--- a/word_document_server/tools/content_tools.py
+++ b/word_document_server/tools/content_tools.py
@@ -357,9 +357,20 @@ async def add_table(document_id: str = None, filename: str = None, rows: int = N
         return error_msg
     
     filename = ensure_docx_extension(filename)
-    
+
     if not os.path.exists(filename):
         return f"Document {filename} does not exist"
+
+    # Validate rows and cols parameters before proceeding
+    if rows is None or cols is None:
+        return "Invalid parameters: 'rows' and 'cols' are required"
+    try:
+        rows = int(rows)
+        cols = int(cols)
+    except (ValueError, TypeError):
+        return "Invalid parameters: 'rows' and 'cols' must be integers"
+    if rows <= 0 or cols <= 0:
+        return "Invalid parameters: 'rows' and 'cols' must be positive integers"
     
     # Check if file is writeable
     is_writeable, error_message = check_file_writeable(filename)


### PR DESCRIPTION
## Summary
- validate `rows` and `cols` parameters in `add_table`

## Testing
- `pytest -q` *(fails: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af866f068832e91097515485216a5