### PR TITLE
Fix __all__ export in session tools

### DIFF
--- a/word_document_server/tools/session_tools.py
+++ b/word_document_server/tools/session_tools.py
@@ -317,4 +317,4 @@ CONSOLIDATED_TOOLS = [
     'open_document', 'close_document', 'list_open_documents', 'set_active_document', 'close_all_documents'  # Original tools (for backward compatibility)
 ]
 
-__all__ = CONSOLIDATED_TOOLS + ['DocumentSessionManager', 'get_session_manager']
+__all__ = CONSOLIDATED_TOOLS + ['get_session_manager']


### PR DESCRIPTION
## Summary
- remove `DocumentSessionManager` from `__all__`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'extract_comments')*

------
https://chatgpt.com/codex/tasks/task_e_684af885e5fc832ea64c0c016cd1ba79